### PR TITLE
予約一覧に無限スクロール機能を追加

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -725,3 +725,58 @@ select,
   border-color: var(--primary-color) !important;
   box-shadow: 0 0 0 2px rgba(67, 97, 238, 0.15);
 }
+
+/* 無限スクロール関連のスタイル */
+.loading-indicator {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  margin: 20px 0;
+  color: var(--text-secondary);
+  gap: 10px;
+  font-size: 0.9rem;
+  animation: fadeIn 0.3s ease;
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  border: 3px solid rgba(0, 0, 0, 0.1);
+  border-radius: 50%;
+  border-top-color: var(--primary-color);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.load-more-btn {
+  margin: 20px auto;
+  background-color: #f0f0f0;
+  color: var(--text-color);
+  border: 1px solid #e0e0e0;
+  width: auto;
+  text-transform: none;
+  padding: 10px 20px;
+  font-size: 0.9rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.load-more-btn:hover {
+  background-color: #e6e6e6;
+  color: var(--text-color);
+  transform: translateY(-2px);
+}
+
+.no-more-reservations {
+  text-align: center;
+  padding: 15px;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 20px;
+  border-top: 1px dashed #e0e0e0;
+}


### PR DESCRIPTION
## 実装内容
Issue #2 に対応し、予約一覧に無限スクロール機能を実装しました。

### 主な変更点
1. **無限スクロール機能の追加**
   - ページネーション機能を導入し、一度に表示される予約数を制限
   - スクロール検知による自動データ読み込み
   - 「もっと見る」ボタンによる手動での追加読み込み

2. **ローディングインジケーターの追加**
   - データ読み込み中の状態を視覚的に表示
   - スピナーアニメーションとテキストによる読み込み状態の表示

3. **スタイル改善**
   - 無限スクロール関連の新しいスタイルを追加
   - ローディングインジケーター用のアニメーション
   - 「もっと見る」ボタンのスタイル

### 改善ポイント
- 予約数が多くても画面が過度に長くならないよう、一度に表示する件数を制限
- 画面下部までスクロールした際に自動的に次のデータを読み込む
- タブ切り替えや日付フィルター適用時はページネーションをリセット
- すべての予約が表示された際は適切なメッセージを表示

## テスト方法
1. 複数の予約を登録（10件以上）
2. 予約一覧が最初は制限された件数で表示されることを確認
3. 下にスクロールするか「もっと見る」ボタンをクリックして追加読み込みを確認
4. タブ切り替えや日付フィルターが正しく機能することを確認

## スクリーンショット
（必要に応じて実際の動作確認用のスクリーンショットをここに追加することをおすすめします）

Closes #2